### PR TITLE
fix: clear chunk caches on unload

### DIFF
--- a/src/main/java/cn/panda/nospawnchunks/NoSpawnChunks.java
+++ b/src/main/java/cn/panda/nospawnchunks/NoSpawnChunks.java
@@ -188,11 +188,31 @@ public class NoSpawnChunks extends JavaPlugin {
 	}
 
 	// 更新区块使用状态
-	public void updateChunkInUse(World world, Chunk chunk, boolean inUse) {
-		Map<Vector, Boolean> chunkUseMap = chunkInUse.computeIfAbsent(world.getName(), k -> new ConcurrentHashMap<>());
-		Vector chunkVector = new Vector(chunk.getX(), 0, chunk.getZ());
-		chunkUseMap.put(chunkVector, inUse);
-	}
+        public void updateChunkInUse(World world, Chunk chunk, boolean inUse) {
+                Map<Vector, Boolean> chunkUseMap = chunkInUse.computeIfAbsent(world.getName(), k -> new ConcurrentHashMap<>());
+                Vector chunkVector = new Vector(chunk.getX(), 0, chunk.getZ());
+                chunkUseMap.put(chunkVector, inUse);
+        }
+
+        /**
+         * 移除给定区块的缓存数据，避免长时间存储导致的内存泄漏。
+         *
+         * @param world 所属世界
+         * @param chunk 目标区块
+         */
+        public void removeChunkData(World world, Chunk chunk) {
+                Vector chunkVector = new Vector(chunk.getX(), 0, chunk.getZ());
+
+                Map<Vector, Boolean> chunkUseMap = chunkInUse.get(world.getName());
+                if (chunkUseMap != null) {
+                        chunkUseMap.remove(chunkVector);
+                }
+
+                Map<Vector, Long> chunkActivityMap = worldChunkActivity.get(world.getName());
+                if (chunkActivityMap != null) {
+                        chunkActivityMap.remove(chunkVector);
+                }
+        }
 
 	// 执行垃圾回收
 	public void runGarbageCollector() {

--- a/src/main/java/cn/panda/nospawnchunks/listeners/WorldListener.java
+++ b/src/main/java/cn/panda/nospawnchunks/listeners/WorldListener.java
@@ -74,9 +74,10 @@ public class WorldListener implements Listener {
 		Chunk chunk = event.getChunk();
 		World world = chunk.getWorld();
 		// 如果配置为所有世界都启用，或者当前世界在配置的世界列表中
-		if (plugin.isAllWorlds() || plugin.getWorlds().contains(world.getName().toLowerCase())) {
-			// 更新区块是否被使用的状态
-			plugin.updateChunkInUse(world, chunk, false);
-		}
-	}
+                if (plugin.isAllWorlds() || plugin.getWorlds().contains(world.getName().toLowerCase())) {
+                        // 更新区块是否被使用的状态，并移除相关缓存
+                        plugin.updateChunkInUse(world, chunk, false);
+                        plugin.removeChunkData(world, chunk);
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- avoid memory leaks by removing chunk usage and activity data when chunks unload

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68958973c00083258474b87a231ea5b1